### PR TITLE
Priya: Updated Hubot http to optionally use auth headers when connecting...

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,13 @@ You need to specify the chat room to use for build events and the cctray.xml to 
       HUBOT_GOCI_CCTRAY_URL="http://my.goserver.example/cctray.xml" \
       bin/hubot
 
+If your GoCD server requires authentication to access cctray.xml you can provide them by setting the environment variables:
+
+      HUBOT_GOCD_USERNAME="username"
+      HUBOT_GOCD_PASSWORD="password"
+
+Preferably, create a user account with read-only access on GoCD for Hubot.
+
 ## Usage
 
 ```

--- a/test/gocd-test.coffee
+++ b/test/gocd-test.coffee
@@ -43,6 +43,7 @@ describe 'goci', ->
               callback? null, null, null)
             httpSpy.get = getSpy
             httpSpy.header = httpSpy
+            httpSpy.headers = httpSpy
             robot.brain.data = {}
             robot.brain.on = sinon.spy()
 
@@ -147,3 +148,13 @@ describe 'goci', ->
 
       expect(robot.brain.data.gociProjects['pixelated-user-agent :: functional-tests'].lastBuildStatus).to.equal('Failure')
       expect(robot.brain.data.gociProjects['pixelated-user-agent :: unit-tests'].lastBuildStatus).to.equal('Success')
+
+  it 'should use auth headers in cctray request if username and password are provided', ->
+    process.env.HUBOT_GOCD_USERNAME = "someuser"
+    process.env.HUBOT_GOCD_PASSWORD = "some password"
+    fs.readFile __dirname + '/fixtures/cctray.xml', (err, data) ->
+      getSpy.returns((callback)->
+        callback? null, null, data)
+      goci.updateBrain()
+      expect(httpSpy.header).to.have.been.calledWith('http://localhost:1345/cctray.xml')
+      expect(Object.keys(robot.brain.data.gociProjects).length).to.equal(11)


### PR DESCRIPTION
... to CCTray

Hubot-gocd can now connect to GoCD servers that require authentication with user/password.

This requires setting two environment variables which are optional:
      HUBOT_GOCD_USERNAME="username"
      HUBOT_GOCD_PASSWORD="password"

Updated README with instructions.
