### PR TITLE
Rename HUBOT_GITHUB_EVENT_NOTIFIER_ROOM to HUBOT_GOCI_EVENT_NOTIFIER_…

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ Add `hubot-gocd` to `external-scripts.json`.
 
 You need to specify the chat room to use for build events and the cctray.xml to use on startup:
 
-    % HUBOT_GITHUB_EVENT_NOTIFIER_ROOM="#roomname" \
+    % HUBOT_GOCI_EVENT_NOTIFIER_ROOM="#roomname" \
       HUBOT_GOCI_CCTRAY_URL="http://my.goserver.example/cctray.xml" \
       bin/hubot
 

--- a/src/scripts/gocd.coffee
+++ b/src/scripts/gocd.coffee
@@ -8,7 +8,7 @@
 #   "underscore": ">=1.6.0"
 #
 # Configuration:
-#   HUBOT_GITHUB_EVENT_NOTIFIER_ROOM - The chatroom to write build events to
+#   HUBOT_GOCI_EVENT_NOTIFIER_ROOM - The chatroom to write build events to
 #   HUBOT_GOCI_CCTRAY_URL - The URL of the cctray.xml
 #
 # Commands:
@@ -22,13 +22,13 @@ cron = require('cron')
 _ = require('underscore')
 parser = require './util/parser'
 
-room =  process.env.HUBOT_GITHUB_EVENT_NOTIFIER_ROOM
+room =  process.env.HUBOT_GOCI_EVENT_NOTIFIER_ROOM
 cctrayUrl = process.env.HUBOT_GOCI_CCTRAY_URL
 
 if not cctrayUrl?
   console.warn("hubot-gocd is not setup to fetch cctray.xml from a url (HUBOT_GOCI_CCTRAY_URL is empty)!")
 if not room?
-  console.warn("hubot-gocd is not setup announce build notifications into a chat room (HUBOT_GITHUB_EVENT_NOTIFIER_ROOM is empty)!")
+  console.warn("hubot-gocd is not setup announce build notifications into a chat room (HUBOT_GOCI_EVENT_NOTIFIER_ROOM is empty)!")
 
 module.exports = (robot) ->
   robot.brain.data.gociProjects or= { }
@@ -96,7 +96,7 @@ fetchAndCompareData = (robot, callback) ->
 
 crontTick = (robot) ->
   fetchAndCompareData robot, (changes) ->
-    room = process.env.HUBOT_GITHUB_EVENT_NOTIFIER_ROOM
+    room = process.env.HUBOT_GOCI_EVENT_NOTIFIER_ROOM
     if room?
       for change in changes
         if "Fixed" == change.type

--- a/test/gocd-test.coffee
+++ b/test/gocd-test.coffee
@@ -48,7 +48,7 @@ describe 'goci', ->
             robot.brain.on = sinon.spy()
 
             process.env.HUBOT_GOCI_CCTRAY_URL = 'http://localhost:1345/cctray.xml'
-            process.env.HUBOT_GITHUB_EVENT_NOTIFIER_ROOM = '#someroom'
+            process.env.HUBOT_GOCI_EVENT_NOTIFIER_ROOM = '#someroom'
 
             goci = require('../src/scripts/gocd')(robot)
 
@@ -127,7 +127,7 @@ describe 'goci', ->
   it 'announces builds that switched state to chat room', ->
     robot.brain.data.gociProjects['pixelated-user-agent :: functional-tests'] = { "name": "pixelated-user-agent :: functional-tests", "lastBuildStatus": "Success", "lastBuildLabel": "37"}
     robot.brain.data.gociProjects["pixelated-user-agent :: unit-tests"] = { "name": "pixelated-user-agent :: unit-tests", "lastBuildStatus": "Failure", "lastBuildLabel": "37"}
-    process.env.HUBOT_GITHUB_EVENT_NOTIFIER_ROOM = '#someroom'
+    process.env.HUBOT_GOCI_EVENT_NOTIFIER_ROOM = '#someroom'
 
     fs.readFile __dirname + '/fixtures/cctray.xml', (err, data) ->
       getSpy.returns((callback)->


### PR DESCRIPTION
Hey fbernitt,
You made an amazing job with this hubot-gocd integration :)

I just changed HUBOT_GITHUB_EVENT_NOTIFIER_ROOM to HUBOT_GOCI_EVENT_NOTIFIER_ROOM.

This allow to have GitHub & GoCD integration to differents channels.

Keep up the good work ;)
